### PR TITLE
Fortify bash in lint-specs.yml

### DIFF
--- a/.github/workflows/lint-specs.yml
+++ b/.github/workflows/lint-specs.yml
@@ -78,19 +78,22 @@ jobs:
       # We don't want this tool to have a low signal-to-noise ratio
       - name: Lint changed spec files
         run: |
-          mkdir -p linted_specs
-          spec-cleaner -o linted_specs ${{ env.updated-specs }}
-          [ -n "$(ls -A linted_specs)" ] \
-          && echo "Specs are not correctly formatted." \
-          && echo "Linting output is available in the linted_specs artifact." \
-          && echo "Please properly format your specs according to that output before merging." \
-          && echo "A diff of the changes required is printed below:" \
-          && spec-cleaner -d --diff-prog="git --no-pager diff" ${{ env.updated-specs }} \
-          && exit 1
+          touch linted_specs.diff
+          spec-cleaner -d --diff-prog="git --no-pager diff" ${{ env.updated-specs }} | tee linted_specs.diff
+          if [ -s linted_specs.diff ]
+          then
+            echo "Specs are not correctly formatted."
+            echo "A diff of the changes required is printed above."
+            echo "Linting output is available in the linted_specs artifact."
+            echo "Please properly format your specs according to the output before merging."
+            exit 1
+          fi
+          done
+          exit 0
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: linted_specs
-          path: linted_specs
+          path: linted_specs.diff
           if-no-files-found: ignore


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx